### PR TITLE
GKR optimization and fixes completed 💯 🥇 

### DIFF
--- a/circuit/src/arithmetic_circuit.rs
+++ b/circuit/src/arithmetic_circuit.rs
@@ -22,7 +22,7 @@ pub struct Layer {
 pub struct Circuit<F: PrimeField> {
     pub layers: Vec<Layer>,
     // Track intermediate values at each layer
-    pub layer_evaluations: Vec<Vec<F>>, 
+    pub layer_evaluations: Vec<Vec<F>>,
     _phantom: PhantomData<F>
 }
 

--- a/polynomials/src/multilinear/evaluation_form.rs
+++ b/polynomials/src/multilinear/evaluation_form.rs
@@ -9,14 +9,14 @@ pub struct MultilinearPolynomial<F: PrimeField> {
 }
 
 impl <F: PrimeField>MultilinearPolynomial<F> {
-    pub fn new(evaluated_values: &Vec<F>) -> Self {
+    pub fn new(evaluated_values: &[F]) -> Self {
         Self {
             evaluated_values: evaluated_values.to_vec()
         }
     }
 
     // The evaluate function calls the partial evaluate multiple times
-    pub fn evaluate(&self, values: &Vec<F>) -> F {
+    pub fn evaluate(&self, values: &[F]) -> F {
         let mut r_polynomial = self.clone();
         let expected_number_of_partial_eval = values.len();
 


### PR DESCRIPTION
- Optimized functions from using `&Vec<F>` to `&[F]`
- Removed excess usage of `.to_vec()`
- Removed duplicate instantiation of `wb_poly` and `wc_poly`, used `.clone()` to create a copy of `wb` as `wc` since they are the same polynomial
- Modified `verify()` function to stop recomputing `wb_poly` and `wc_poly` instead we used evaluated value of `wb` and `wc` received from the `prover` to computed the expected claim.
- Implemented function to computed expected claim using the linear combination : 2 - 1 trick.
- Ensured that all tests are passing
- GKR 💯  completed 👍 